### PR TITLE
Add option g:mediawiki_editor_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ If you don't specify these settings, vim-mediawiki-editor will prompt you when y
 
 The URL of the site you're editing. For the English wikipedia, that'd be `en.wikipedia.org`.
 
+#### g:mediawiki_editor_path
+
+The MediaWiki [script path](https://www.mediawiki.org/wiki/Manual:$wgScriptPath).
+For the wikipedias and other WMF wikis, this is `/w/`, but for other wikis it can be `/`, `/wiki/`,
+or some other value.
+
 #### g:mediawiki_editor_username
 
 Your account username.

--- a/plugin/mediawiki_editor.py
+++ b/plugin/mediawiki_editor.py
@@ -43,11 +43,11 @@ def var_exists(var):
     return bool(int(vim.eval("exists('%s')" % sq_escape(var))))
 
 
-def get_from_config_or_prompt(var, prompt, password=False):
+def get_from_config_or_prompt(var, prompt, password=False, text=''):
     if var_exists(var):
         return vim.eval(var)
     else:
-        resp = input(prompt, password=password)
+        resp = input(prompt, text=text, password=password)
         vim.command("let %s = '%s'" % (var, sq_escape(resp)))
         return resp
 
@@ -61,7 +61,10 @@ def site():
     if site.cached_site:
         return site.cached_site
 
-    s = mwclient.Site(base_url())
+    s = mwclient.Site(base_url(),
+                      path=get_from_config_or_prompt('g:mediawiki_editor_path',
+                                                     'Mediawiki Script Path: ',
+                                                     text='/w/'))
     try:
         s.login(
                 get_from_config_or_prompt('g:mediawiki_editor_username',


### PR DESCRIPTION
Useful when using the plugin with any non-WMF wiki as exemplified in #2.
