### PR TITLE
Add ability to specify URI scheme

### DIFF
--- a/plugin/mediawiki_editor.py
+++ b/plugin/mediawiki_editor.py
@@ -20,6 +20,11 @@ except NameError:
 if not from_cmdline:
     import vim
 
+# Configuration information.
+config = {
+        # Only support http and https
+        'schemes' : ['http','https']
+        }
 
 # Utility.
 
@@ -42,6 +47,13 @@ def input(prompt, text='', password=False):
 def var_exists(var):
     return bool(int(vim.eval("exists('%s')" % sq_escape(var))))
 
+def get_from_config_or_default(var, default):
+    if var_exists(var):
+        value = vim.eval(var)
+        return value if (value in config['schemes']) else default
+    else:
+        return default
+
 
 def get_from_config_or_prompt(var, prompt, password=False, text=''):
     if var_exists(var):
@@ -61,7 +73,9 @@ def site():
     if site.cached_site:
         return site.cached_site
 
-    s = mwclient.Site(base_url(),
+    scheme = get_from_config_or_default('g:mediawiki_editor_uri_scheme',
+                                        'https')
+    s = mwclient.Site((scheme, base_url()),
                       path=get_from_config_or_prompt('g:mediawiki_editor_path',
                                                      'Mediawiki Script Path: ',
                                                      text='/w/'))


### PR DESCRIPTION
The wiki at work only support http. I added the ability to specify the scheme in a configuration variable in .vimrc
