### PR TITLE
decode article_name from internally used utf-8

### DIFF
--- a/plugin/mediawiki_editor.py
+++ b/plugin/mediawiki_editor.py
@@ -115,6 +115,7 @@ def infer_default(article_name):
 # Commands.
 
 def mw_read(article_name):
+    article_name = article_name.decode('utf-8')
     s = site()
     vim.current.buffer[:] = s.Pages[article_name].text().split("\n")
     vim.command('set ft=mediawiki')
@@ -123,6 +124,7 @@ def mw_read(article_name):
 
 def mw_write(article_name):
     article_name = infer_default(article_name)
+    article_name = article_name.decode('utf-8')
 
     s = site()
     page = s.Pages[article_name]
@@ -141,6 +143,7 @@ def mw_write(article_name):
 
 def mw_diff(article_name):
     article_name = infer_default(article_name)
+    article_name = article_name.decode('utf-8')
 
     s = site()
     vim.command('diffthis')
@@ -154,6 +157,7 @@ def mw_diff(article_name):
 
 def mw_browse(article_name):
     article_name = infer_default(article_name)
+    article_name = article_name.decode('utf-8')
 
     url = 'http://%s/wiki/%s' % (base_url(), article_name)
     if not var_exists('g:loaded_netrw'):


### PR DESCRIPTION
This should fix issue https://github.com/aquach/vim-mediawiki-editor/issues/7.