### PR TITLE
Add HTTP Basic Auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Your account username.
 
 Your account password. I recommend putting the URL and username in your `.vimrc` and letting Vim ask for your password.
 
+#### g:mediawiki_basicauth_enabled
+
+Set this to `on` to enable HTTP Basic Authentication.
+
+#### g:mediawiki_basicauth_username
+
+The HTTP Basic Auth Username. Will be prompted if not provided and basic `g:mediawiki_basicauth_enabled` is on.
+
+#### g:mediawiki_basicauth_password
+
+The HTTP Basic Auth Password. Will be prompted if not provided and basic `g:mediawiki_basicauth_enabled` is on.
+
 ## Contributing
 
 This plugin is currently quite simple. Contributions, suggestions, and feedback are all welcomed!

--- a/plugin/mediawiki_editor.py
+++ b/plugin/mediawiki_editor.py
@@ -75,7 +75,18 @@ def site():
     if scheme not in VALID_PROTOCOLS:
         scheme = 'https'
 
+    if get_from_config('g:mediawiki_basicauth_enabled'):
+        httpauth = (
+            get_from_config_or_prompt('g:mediawiki_basicauth_username',
+                                      'Basic Auth Username: '),
+            get_from_config_or_prompt('g:mediawiki_basicauth_password',
+                                      'Basic Auth Password: ', password=True)
+        )
+    else:
+        httpauth = None
+
     s = mwclient.Site((scheme, base_url()),
+                      httpauth=httpauth,
                       path=get_from_config_or_prompt('g:mediawiki_editor_path',
                                                      'Mediawiki Script Path: ',
                                                      text='/w/'))


### PR DESCRIPTION
Hey Alex,

Thank you very much for this plugin!

My use case is slightly odd - I access a personal mediawiki instance which sits behind HTTP Basic protection. As you use the excellent `requests` library it was quite easy to add support.

I'm dubious that anyone but myself will ever want the functionality to support HTTP Basic added, but just in case I'm sending this PR to you.

Again, thank you for the plugin. Have an excellent day!

-Mike