### PR TITLE
Add dynamic syntax highlighting

### DIFF
--- a/plugin/mediawiki_editor.py
+++ b/plugin/mediawiki_editor.py
@@ -82,6 +82,24 @@ def base_url():
     )
 
 
+def get_filetype(article_name):
+    config_namespaces = ["User:", "MediaWiki:"]
+    config_extensions = {
+                          ".css": "css",
+                          ".js": "javascript",
+                          ".json": "json"
+                         }
+    if article_name.startswith("Module:"):
+        return "lua"
+    for namespace in config_namespaces:
+        for extension in config_extensions:
+            if article_name.startswith(namespace) and article_name.endswith(extension):
+                return config_extensions[extension]
+
+    return "mediawiki"
+
+
+
 def get_logged_in_client(
     uri_scheme,
     base_url,
@@ -203,7 +221,7 @@ def mw_read(article_name):
     vim.current.buffer[:] = (
         s.Pages[article_name].text().split("\n")
     )
-    vim.command("set ft=mediawiki")
+    vim.command(f"set ft={get_filetype(article_name)}")
     vim.command(
         "let b:article_name = '%s'"
         % sq_escape(article_name)
@@ -245,7 +263,7 @@ def mw_diff(article_name):
     vim.command(
         "setlocal buftype=nofile bufhidden=delete nobuflisted"
     )
-    vim.command("set ft=mediawiki")
+    vim.command(f"set ft={get_filetype(article_name)}")
     vim.current.buffer[:] = (
         s.Pages[article_name].text().split("\n")
     )

--- a/plugin/mediawiki_editor.py
+++ b/plugin/mediawiki_editor.py
@@ -91,11 +91,11 @@ def get_filetype(article_name):
                          }
     if article_name.startswith("Module:"):
         return "lua"
-    for namespace in config_namespaces:
-        for extension in config_extensions:
-            if article_name.startswith(namespace) and article_name.endswith(extension):
-                return config_extensions[extension]
-
+    if any((article_name.startswith(n) for n in config_namespaces)):
+        for extension, filetype in config_extensions.items():
+            if article_name.endswith(extension):
+                return filetype
+    
     return "mediawiki"
 
 


### PR DESCRIPTION
Normally, all files in all namespaces are set to the `mediawiki` filetype. This patch detects the file's type and sets `filetype` to an appropriate value. For example:
* Anything in the `MediaWiki` and `User` namespaces and has a `js`/`css`/`json` file extension (eg. `MediaWiki:Common.js`, `User:Aquach/global.css`) gets set to the appropriate syntax type.
* Anything in the `Module` namespace gets set to the `lua` syntax type.
* Everything else is set to the `mediawiki` syntax type.
* This behavior is identical to MediaWiki's default behavior.

## Implementation

This adds a new function which detects the file's type through its name and returns an appropriate `filetype` value. This function then gets called in `mw_read` and `mw_diff` to set the `filetype`.